### PR TITLE
fix: widen ID fields from u32 to u64

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ mod util;
 enum Program {
     StartTimer {
         #[structopt(short, long)]
-        pid: Option<u32>,
+        pid: Option<u64>,
         #[structopt(short = "n", long)]
         project_name: Option<String>,
         #[structopt(short, long)]
@@ -59,7 +59,7 @@ async fn main() -> Result<(), util::AnyError> {
             project_name,
             description,
         } => {
-            let mut real_pid: Option<u32> = pid;
+            let mut real_pid: Option<u64> = pid;
             if pid.is_none() {
                 if let Some(n) = project_name {
                     let projects = client.get_all_projects_of_user().await.unwrap();
@@ -130,7 +130,7 @@ async fn main() -> Result<(), util::AnyError> {
             start_date,
             end_date,
         } => {
-            let mut project_ids: Option<Vec<u32>> = None;
+            let mut project_ids: Option<Vec<u64>> = None;
 
             if let Some(name) = project_name {
                 let projects = client.get_all_projects_of_user().await?;

--- a/src/toggl_client.rs
+++ b/src/toggl_client.rs
@@ -103,7 +103,7 @@ impl TogglClient<'_> {
         Ok(projects)
     }
 
-    pub async fn get_projects(&self, workspace_id: u32) -> Result<Vec<Project>, AnyError> {
+    pub async fn get_projects(&self, workspace_id: u64) -> Result<Vec<Project>, AnyError> {
         let path = format!("/workspaces/{}/projects", workspace_id);
         Ok(self.get::<Vec<Project>>(&path).await?)
     }
@@ -132,7 +132,7 @@ impl TogglClient<'_> {
 
     pub async fn stop_time_entry(
         &self,
-        time_entry_id: u32,
+        time_entry_id: u64,
     ) -> Result<Option<TimeEntry>, Box<dyn std::error::Error>> {
         let workspace_id = self.get_workspaces().await?.first().unwrap().id;
         let path = format!(

--- a/src/toggl_types.rs
+++ b/src/toggl_types.rs
@@ -7,9 +7,9 @@ pub struct Data<T> {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TimeEntry {
-    pub id: u32,
-    pub wid: u32,
-    pub pid: Option<u32>,
+    pub id: u64,
+    pub wid: u64,
+    pub pid: Option<u64>,
     pub billable: bool,
     pub start: String,
     pub stop: Option<String>,
@@ -17,7 +17,7 @@ pub struct TimeEntry {
     pub description: String,
     pub duronly: bool,
     pub at: String,
-    pub uid: u32,
+    pub uid: u64,
 }
 
 impl TimeEntry {
@@ -36,7 +36,7 @@ pub struct TimeEntryCreateParamWrapped {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TimeEntryCreateParam {
-    pub pid: Option<u32>,
+    pub pid: Option<u64>,
     pub description: String,
     pub created_with: String,
 }
@@ -48,9 +48,9 @@ pub struct TimeEntryStopParam {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Project {
-    pub id: u32,
-    pub wid: u32,
-    pub cid: Option<u32>,
+    pub id: u64,
+    pub wid: u64,
+    pub cid: Option<u64>,
     pub name: String,
     pub at: String,
     pub created_at: String,
@@ -58,9 +58,9 @@ pub struct Project {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Workspace {
-    pub id: u32,
+    pub id: u64,
     pub name: String,
-    pub profile: Option<u32>,
+    pub profile: Option<u64>,
     pub premium: bool,
     pub admin: bool,
     pub default_hourly_rate: Option<i64>,
@@ -83,14 +83,14 @@ pub struct DetailedReportSearchParam {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_date: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub project_ids: Option<Vec<u32>>,
+    pub project_ids: Option<Vec<u64>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DetailedReportEntry {
     pub id: u64,
-    pub user_id: u32,
-    pub project_id: Option<u32>,
+    pub user_id: u64,
+    pub project_id: Option<u64>,
     pub description: Option<String>,
     pub start: String,
     pub end: String,


### PR DESCRIPTION
## Summary
- Toggl API now returns IDs exceeding `u32::MAX` (e.g. `4295350754`), causing `view-timer` and other commands to fail with a deserialization error
- Changed all ID fields (`id`, `wid`, `pid`, `uid`, `cid`, `workspace_id`, `time_entry_id`, `project_ids`, etc.) from `u32` to `u64` across `toggl_types.rs`, `toggl_client.rs`, and `main.rs`

## Test plan
- [x] `cargo build` compiles without errors
- [x] `cargo run -- view-timer` successfully returns the current time entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)